### PR TITLE
Support for onchange event

### DIFF
--- a/src/CibulCalendar.js
+++ b/src/CibulCalendar.js
@@ -648,6 +648,7 @@
     _onSelect = function(newSelection) {
 
       element.value = newSelection.begin?_dateToString(newSelection.begin) + (newSelection.begin!=newSelection.end?options.separator+_dateToString(newSelection.end):''):_dateToString(newSelection);
+      fireEvent(element, 'change');
 
       setTimeout(_blur,200);
     },
@@ -697,6 +698,19 @@
       } else {
           elem["on"+type]=eventHandle;
       }  
+    });
+  },
+  fireEvent = function(elem, types) {
+    if (elem == null || elem == undefined) return;
+    if (typeof types == 'string') types = [types];
+    forEach(types, function(type){
+      if ("fireEvent" in elem) {
+        elem.fireEvent(type);
+      } else {
+        var evt = document.createEvent("HTMLEvents");
+        evt.initEvent(type, false, true);
+        elem.dispatchEvent(evt);
+      }
     });
   },
   makeUnselectable = function(node) {


### PR DESCRIPTION
I added support for the onchange event of the input field. I personally needed it for my project, and you might like to use it too. Thanks for creating the plugin!

Used code to fire event found here:
http://stackoverflow.com/a/2856602/1047398
